### PR TITLE
Copied sqlite3 files to build directories

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -87,7 +87,7 @@ add_dependencies(bzip2::bzip2 bzip2)
 target_link_directories(bzip2::bzip2 INTERFACE ${install_dir}/src/bzip2)
 target_link_libraries(bzip2::bzip2 INTERFACE libbz2.lib)
 target_include_directories(bzip2::bzip2 INTERFACE ${install_dir}/src/bzip2)
-file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} CMAKE_BINARY_DIR)
+file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} __native_binary_dir)
 
 if(MIOPEN_ENABLE_SQLITE)
     ExternalProject_Add(
@@ -98,16 +98,14 @@ if(MIOPEN_ENABLE_SQLITE)
             UPDATE_DISCONNECTED true
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ${NMAKE_EXECUTABLE} /f ..\\sqlite3\\Makefile.msc TOP=..\\sqlite3
-            INSTALL_COMMAND cmd.exe /c copy /y sqlite3.dll "${CMAKE_BINARY_DIR}\\bin" && copy /y sqlite3.lib "${CMAKE_BINARY_DIR}\\lib" && for %I in (sqlite3.h sqlite3ext.h) do copy /y %I "${CMAKE_BINARY_DIR}\\include"
+            INSTALL_COMMAND cmd.exe /c copy /y sqlite3.dll "${__native_binary_dir}\\bin" && copy /y sqlite3.lib "${__native_binary_dir}\\lib" && for %I in (sqlite3.h sqlite3ext.h) do copy /y %I "${__native_binary_dir}\\include"
     )
-
-    ExternalProject_Get_Property(sqlite3 install_dir)
 
     add_library(sqlite3::sqlite3 INTERFACE IMPORTED GLOBAL)
     add_dependencies(sqlite3::sqlite3 sqlite3)
-    target_link_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}\\lib)
+    target_link_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}/lib)
     target_link_libraries(sqlite3::sqlite3 INTERFACE sqlite3.lib)
-    target_include_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}\\include)
+    target_include_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}/include)
 endif()
 
 set(_CXX_FLAGS

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -97,7 +97,9 @@ if(MIOPEN_ENABLE_SQLITE)
             UPDATE_DISCONNECTED true
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ${NMAKE_EXECUTABLE} /f ..\\sqlite3\\Makefile.msc TOP=..\\sqlite3
-            INSTALL_COMMAND cmd.exe /c for %I in (sqlite3.dll sqlite3.lib sqlite3.h sqlite3ext.h) do copy /y %I ..\\..)
+            INSTALL_COMMAND cmd.exe /c for %I in (sqlite3.dll sqlite3.lib sqlite3.h sqlite3ext.h) do copy /y %I ..\\..
+            COMMAND cmd.exe /c copy /y ..\\..\\sqlite3.dll ..\\..\\..\\..\\bin && copy /y ..\\..\\sqlite3.lib ..\\..\\..\\..\\lib && for %I in (..\\..\\sqlite3.h ..\\..\\sqlite3ext.h) do copy /y %I ..\\..\\..\\..\\include\\miopen
+    )
 
     ExternalProject_Get_Property(sqlite3 install_dir)
 
@@ -106,6 +108,7 @@ if(MIOPEN_ENABLE_SQLITE)
     target_link_directories(sqlite3::sqlite3 INTERFACE ${install_dir})
     target_link_libraries(sqlite3::sqlite3 INTERFACE sqlite3.lib)
     target_include_directories(sqlite3::sqlite3 INTERFACE ${install_dir})
+
 endif()
 
 set(_CXX_FLAGS

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -87,6 +87,7 @@ add_dependencies(bzip2::bzip2 bzip2)
 target_link_directories(bzip2::bzip2 INTERFACE ${install_dir}/src/bzip2)
 target_link_libraries(bzip2::bzip2 INTERFACE libbz2.lib)
 target_include_directories(bzip2::bzip2 INTERFACE ${install_dir}/src/bzip2)
+file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} CMAKE_BINARY_DIR)
 
 if(MIOPEN_ENABLE_SQLITE)
     ExternalProject_Add(
@@ -97,18 +98,16 @@ if(MIOPEN_ENABLE_SQLITE)
             UPDATE_DISCONNECTED true
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ${NMAKE_EXECUTABLE} /f ..\\sqlite3\\Makefile.msc TOP=..\\sqlite3
-            INSTALL_COMMAND cmd.exe /c for %I in (sqlite3.dll sqlite3.lib sqlite3.h sqlite3ext.h) do copy /y %I ..\\..
-            COMMAND cmd.exe /c copy /y ..\\..\\sqlite3.dll ..\\..\\..\\..\\bin && copy /y ..\\..\\sqlite3.lib ..\\..\\..\\..\\lib && for %I in (..\\..\\sqlite3.h ..\\..\\sqlite3ext.h) do copy /y %I ..\\..\\..\\..\\include\\miopen
+            INSTALL_COMMAND cmd.exe /c copy /y sqlite3.dll "${CMAKE_BINARY_DIR}\\bin" && copy /y sqlite3.lib "${CMAKE_BINARY_DIR}\\lib" && for %I in (sqlite3.h sqlite3ext.h) do copy /y %I "${CMAKE_BINARY_DIR}\\include"
     )
 
     ExternalProject_Get_Property(sqlite3 install_dir)
 
     add_library(sqlite3::sqlite3 INTERFACE IMPORTED GLOBAL)
     add_dependencies(sqlite3::sqlite3 sqlite3)
-    target_link_directories(sqlite3::sqlite3 INTERFACE ${install_dir})
+    target_link_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}\\lib)
     target_link_libraries(sqlite3::sqlite3 INTERFACE sqlite3.lib)
-    target_include_directories(sqlite3::sqlite3 INTERFACE ${install_dir})
-
+    target_include_directories(sqlite3::sqlite3 INTERFACE ${CMAKE_BINARY_DIR}\\include)
 endif()
 
 set(_CXX_FLAGS


### PR DESCRIPTION
After installation in MIOpen\build\extern\sqlite3-prefix copied sqlite3 files to appropriate directories:

- sqlite3.dll to build/bin
- sqlite3.lib to build/lib
- sqlite3.h and sqlite3ext.h to build/include/miopen

@apwojcik 